### PR TITLE
[FEAT] #25 : 유저 캘린더 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
+++ b/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
@@ -34,6 +34,9 @@ public enum SuccessStatus implements BaseStatus {
     SUBMISSION_PREVIEW_SUCCESS("SUBMISSION_200", HttpStatus.OK, "작품 미리보기 조회 성공"),
     SUBMISSION_DETAIL_SUCCESS("SUBMISSION_200", HttpStatus.OK, "작품 상세조회 성공"),
 
+    //캘린더 조회
+    CALENDAR_GET_SUCCESS("CALENDAR_200", HttpStatus.OK, "유저 캘린더 조회 성공"),
+
     //s3
     S3_UPLOAD_SUCCESS("S3_200", HttpStatus.OK, "Presigned URL 발급 성공");
     

--- a/src/main/java/com/umc/greaming/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/controller/CalendarController.java
@@ -1,0 +1,32 @@
+package com.umc.greaming.domain.calendar.controller;
+
+import com.umc.greaming.common.response.ApiResponse;
+import com.umc.greaming.common.status.success.SuccessStatus;
+import com.umc.greaming.domain.calendar.dto.response.UserCalendarResponse;
+import com.umc.greaming.domain.calendar.service.CalendarQueryService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class CalendarController {
+
+    private final CalendarQueryService calendarQueryService;
+
+    @GetMapping("/{userId}/calendar")
+    public ResponseEntity<ApiResponse<UserCalendarResponse>> getUserCalendar(
+            @PathVariable @Positive Long userId,
+            @RequestParam @Min(2000) @Max(2100) int year,
+            @RequestParam @Min(1) @Max(12) int month
+    ) {
+        UserCalendarResponse response = calendarQueryService.getUserCalendar(userId, year, month);
+        return ApiResponse.success(SuccessStatus.CALENDAR_GET_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/umc/greaming/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/converter/CalendarConverter.java
@@ -1,0 +1,28 @@
+package com.umc.greaming.domain.calendar.converter;
+
+import com.umc.greaming.domain.calendar.dto.response.ChallengeCalendarResponse;
+import com.umc.greaming.domain.calendar.dto.response.ParticipatedAtResponse;
+import com.umc.greaming.domain.calendar.dto.response.UserCalendarResponse;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+public class CalendarConverter {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd");
+
+    public UserCalendarResponse toResponse(List<LocalDate> dailyDates, List<LocalDate> weeklyDates) {
+        List<ParticipatedAtResponse> daily = dailyDates.stream()
+                .map(d -> new ParticipatedAtResponse(d.format(FORMATTER)))
+                .toList();
+
+        List<ParticipatedAtResponse> weekly = weeklyDates.stream()
+                .map(d -> new ParticipatedAtResponse(d.format(FORMATTER)))
+                .toList();
+
+        return new UserCalendarResponse(new ChallengeCalendarResponse(daily, weekly));
+    }
+}

--- a/src/main/java/com/umc/greaming/domain/calendar/dto/response/ChallengeCalendarResponse.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/dto/response/ChallengeCalendarResponse.java
@@ -1,0 +1,8 @@
+package com.umc.greaming.domain.calendar.dto.response;
+
+import java.util.List;
+
+public record ChallengeCalendarResponse(
+        List<ParticipatedAtResponse> dailyChallenge,
+        List<ParticipatedAtResponse> weeklyChallenge
+) {}

--- a/src/main/java/com/umc/greaming/domain/calendar/dto/response/ParticipatedAtResponse.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/dto/response/ParticipatedAtResponse.java
@@ -1,0 +1,8 @@
+package com.umc.greaming.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ParticipatedAtResponse(
+        @JsonProperty("participated_at")
+        String participatedAt
+) {}

--- a/src/main/java/com/umc/greaming/domain/calendar/dto/response/UserCalendarResponse.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/dto/response/UserCalendarResponse.java
@@ -1,0 +1,8 @@
+package com.umc.greaming.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserCalendarResponse(
+        @JsonProperty("challenge_calendar")
+        ChallengeCalendarResponse challengeCalendar
+) {}

--- a/src/main/java/com/umc/greaming/domain/calendar/entity/ChallengeParticipation.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/entity/ChallengeParticipation.java
@@ -1,0 +1,30 @@
+package com.umc.greaming.domain.calendar.entity;
+
+import com.umc.greaming.domain.calendar.enums.ChallengeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "challenge_participations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeParticipation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "challenge_type", nullable = false, length = 20)
+    private ChallengeType challengeType;
+
+    @Column(name = "participated_at", nullable = false)
+    private LocalDate participatedAt;
+}

--- a/src/main/java/com/umc/greaming/domain/calendar/enums/ChallengeType.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/enums/ChallengeType.java
@@ -1,0 +1,6 @@
+package com.umc.greaming.domain.calendar.enums;
+
+public enum ChallengeType {
+    DAILY,
+    WEEKLY
+}

--- a/src/main/java/com/umc/greaming/domain/calendar/repository/ChallengeParticipationRepository.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/repository/ChallengeParticipationRepository.java
@@ -1,0 +1,28 @@
+package com.umc.greaming.domain.calendar.repository;
+
+import com.umc.greaming.domain.calendar.entity.ChallengeParticipation;
+import com.umc.greaming.domain.calendar.enums.ChallengeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ChallengeParticipationRepository extends JpaRepository<ChallengeParticipation, Long> {
+
+    @Query("""
+        select distinct cp.participatedAt
+        from ChallengeParticipation cp
+        where cp.userId = :userId
+          and cp.challengeType = :type
+          and cp.participatedAt between :start and :end
+        order by cp.participatedAt asc
+    """)
+    List<LocalDate> findDistinctParticipatedAt(
+            @Param("userId") Long userId,
+            @Param("type") ChallengeType type,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+}

--- a/src/main/java/com/umc/greaming/domain/calendar/service/CalendarQueryService.java
+++ b/src/main/java/com/umc/greaming/domain/calendar/service/CalendarQueryService.java
@@ -1,0 +1,44 @@
+package com.umc.greaming.domain.calendar.service;
+
+import com.umc.greaming.common.exception.GeneralException;
+import com.umc.greaming.common.status.error.ErrorStatus;
+import com.umc.greaming.domain.calendar.converter.CalendarConverter;
+import com.umc.greaming.domain.calendar.dto.response.UserCalendarResponse;
+import com.umc.greaming.domain.calendar.enums.ChallengeType;
+import com.umc.greaming.domain.calendar.repository.ChallengeParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarQueryService {
+
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final CalendarConverter calendarConverter;
+
+    // 특정 월의 DAILY/WEEKLY 참여 날짜 리스트 반환
+    public UserCalendarResponse getUserCalendar(Long userId, int year, int month) {
+        if (month < 1 || month > 12) {
+            throw new GeneralException(ErrorStatus.VALIDATION_ERROR);
+        }
+
+        YearMonth ym = YearMonth.of(year, month);
+        LocalDate start = ym.atDay(1);
+        LocalDate end = ym.atEndOfMonth();
+
+        List<LocalDate> dailyDates = challengeParticipationRepository.findDistinctParticipatedAt(
+                userId, ChallengeType.DAILY, start, end
+        );
+        List<LocalDate> weeklyDates = challengeParticipationRepository.findDistinctParticipatedAt(
+                userId, ChallengeType.WEEKLY, start, end
+        );
+
+        return calendarConverter.toResponse(dailyDates, weeklyDates);
+    }
+}


### PR DESCRIPTION
## 📝 이슈 번호
Closes #25 

## 🛠️ 변경 사항 (Changes)
- 유저 캘린더 조회(페이지) API 구현 (GET /api/users/{userId}/calendar)
- year/month 파라미터 검증 및 월 범위(start~end) 계산
- Daily/Weekly 참여 날짜 조회 쿼리 작성 및 응답 DTO/Converter 구성
- VALIDATION_ERROR 예외 처리 및 SuccessStatus 적용

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img width="471" height="367" alt="image" src="https://github.com/user-attachments/assets/64b79c15-ebe7-466a-a7a6-3b2f57833ce9" />

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?