### PR TITLE
[FEAT] #39 dev도 프로덕션과 동일하게 secure=true, samesite=None으로 처리

### DIFF
--- a/src/main/java/com/umc/greaming/common/config/CookieConfig.java
+++ b/src/main/java/com/umc/greaming/common/config/CookieConfig.java
@@ -66,10 +66,10 @@ public class CookieConfig {
      * - 그 외: request.isSecure() 기반 (HTTPS 요청인 경우 true)
      */
     private boolean isSecureEnvironment(HttpServletRequest request) {
-        if ("prod".equals(activeProfile)) {
+        if ("prod".equals(activeProfile) || "dev".equals(activeProfile)) {
             return true;
         }
-        // 로컬/개발 환경에서는 요청 스킴에 따라 결정
+        // 로컬 환경에서는 요청 스킴에 따라 결정
         return request != null && request.isSecure();
     }
 


### PR DESCRIPTION
## 📝 이슈 번호
Closes #42 

## 🛠️ 변경 사항 (Changes)
- dev 프로필에서도 `Secure=true; SameSite=None`으로 쿠키 설정하여 cross-site 쿠키 전송  
  허용
- CORS에 프론트엔드 로컬 개발 도메인(`localhost:5173`) 추가                             
- `forward-headers-strategy: native` 설정으로 리버스 프록시 뒤 HTTPS 감지               
- OAuth2 콜백 주소를 프론트엔드 주소로 변경  

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?