### PR TITLE
[FEAT] #51 dev deploy-dev.yml의 swagger url을 greaming 주소로 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -59,7 +59,7 @@ jobs:
             echo "OAUTH2_KAKAO_CLIENT_ID=${{ secrets.OAUTH2_KAKAO_CLIENT_ID }}" >> .env
             echo "OAUTH2_KAKAO_CLIENT_SECRET=${{ secrets.OAUTH2_KAKAO_CLIENT_SECRET }}" >> .env
             echo "OAUTH2_REDIRECT_URI=http://localhost:5173/auth/callback" >> .env
-            echo "SWAGGER_URL=http://${{ secrets.EC2_HOST }}:8081" >> .env
+            echo "SWAGGER_URL=https://api.greaming.com" >> .env
 
             sudo docker run -d -p 8081:8081 --name greaming-dev \
             --env-file .env \


### PR DESCRIPTION
## 📝 이슈 번호
Closes #51 

## 🛠️ 변경 사항 (Changes)
- 배포 스웨거 주소 greaming 주소로 변경
-

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?