### PR TITLE
[FIX] #68: 유저 검색 관련 api 생성

### DIFF
--- a/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
+++ b/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
@@ -46,6 +46,8 @@ public enum SuccessStatus implements BaseStatus {
     USER_CHECK_REGISTERED_SUCCESS("USER_200", HttpStatus.OK, "프로필 등록 여부 조회 성공"),
     USER_UPDATE_INFO_SUCCESS("USER_200", HttpStatus.OK, "유저 정보 수정 성공"),
     USER_GET_INFO_SUCCESS("USER_200", HttpStatus.OK, "유저 정보 조회 성공"),
+    USER_SEARCH_SUCCESS("USER_200", HttpStatus.OK, "유저 검색 성공"),
+    USER_CHECK_IS_ME_SUCCESS("USER_200", HttpStatus.OK, "본인 여부 확인 성공"),
 
     //홈
     HOME_SUCCESS("HOME_200", HttpStatus.OK , "홈화면 조회 성공" ),

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
@@ -4,6 +4,7 @@ import com.umc.greaming.common.response.ApiResponse;
 import com.umc.greaming.domain.user.dto.request.RegistInfoRequest;
 import com.umc.greaming.domain.user.dto.request.UpdateUserInfoRequest;
 import com.umc.greaming.domain.user.dto.response.UserInfoResponse;
+import com.umc.greaming.domain.user.dto.response.UserSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -305,5 +306,125 @@ public interface UserApi {
     @GetMapping("/{userId}/info")
     ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(
             @Parameter(description = "조회할 유저 ID") @PathVariable Long userId
+    );
+
+    @Operation(
+            summary = "닉네임으로 유저 검색",
+            description = """
+                    닉네임 키워드로 유저를 검색하여 유저 ID 목록을 반환합니다.
+
+                    - 닉네임에 키워드가 포함된 ACTIVE 상태의 유저를 검색합니다.
+                    - 인증이 필요합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "유저 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "USER_200",
+                                      "message": "유저 검색 성공",
+                                      "result": {
+                                        "users": [
+                                          {
+                                            "userId": 1,
+                                            "nickname": "그림쟁이",
+                                            "profileImgUrl": "https://s3.amazonaws.com/..."
+                                          },
+                                          {
+                                            "userId": 5,
+                                            "nickname": "그림그리는사람",
+                                            "profileImgUrl": null
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMM_401",
+                                      "message": "인증이 필요합니다.",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/search")
+    ResponseEntity<ApiResponse<UserSearchResponse>> searchByNickname(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "검색할 닉네임 키워드", example = "그림") @RequestParam String nickname
+    );
+
+    @Operation(
+            summary = "본인 여부 확인",
+            description = """
+                    주어진 유저 ID가 현재 로그인한 사용자 본인인지 확인합니다.
+
+                    - `isMe: true`이면 본인, `false`이면 다른 사용자입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "본인 여부 확인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "USER_200",
+                                      "message": "본인 여부 확인 성공",
+                                      "result": {
+                                        "isMe": true
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMM_401",
+                                      "message": "인증이 필요합니다.",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/{targetUserId}/is-me")
+    ResponseEntity<ApiResponse<java.util.Map<String, Boolean>>> checkIsMe(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "확인할 유저 ID") @PathVariable Long targetUserId
     );
 }

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.umc.greaming.common.status.success.SuccessStatus;
 import com.umc.greaming.domain.user.dto.request.RegistInfoRequest;
 import com.umc.greaming.domain.user.dto.request.UpdateUserInfoRequest;
 import com.umc.greaming.domain.user.dto.response.UserInfoResponse;
+import com.umc.greaming.domain.user.dto.response.UserSearchResponse;
 import com.umc.greaming.domain.user.service.UserQueryService;
 import com.umc.greaming.domain.user.service.UserService;
 import jakarta.validation.Valid;
@@ -61,5 +62,25 @@ public class UserController implements UserApi {
     ) {
         UserInfoResponse response = userQueryService.getUserInfo(userId);
         return ApiResponse.success(SuccessStatus.USER_GET_INFO_SUCCESS, response);
+    }
+
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<UserSearchResponse>> searchByNickname(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam String nickname
+    ) {
+        UserSearchResponse response = userQueryService.searchByNickname(nickname);
+        return ApiResponse.success(SuccessStatus.USER_SEARCH_SUCCESS, response);
+    }
+
+    @Override
+    @GetMapping("/{targetUserId}/is-me")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkIsMe(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long targetUserId
+    ) {
+        boolean isMe = userId.equals(targetUserId);
+        return ApiResponse.success(SuccessStatus.USER_CHECK_IS_ME_SUCCESS, Map.of("isMe", isMe));
     }
 }

--- a/src/main/java/com/umc/greaming/domain/user/dto/response/UserSearchResponse.java
+++ b/src/main/java/com/umc/greaming/domain/user/dto/response/UserSearchResponse.java
@@ -1,0 +1,39 @@
+package com.umc.greaming.domain.user.dto.response;
+
+import com.umc.greaming.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "유저 닉네임 검색 응답")
+public record UserSearchResponse(
+        @Schema(description = "검색 결과 목록")
+        List<UserSearchItem> users
+) {
+    public static UserSearchResponse from(List<User> users, java.util.function.Function<String, String> urlResolver) {
+        List<UserSearchItem> items = users.stream()
+                .map(user -> UserSearchItem.from(user, urlResolver))
+                .toList();
+        return new UserSearchResponse(items);
+    }
+
+    @Schema(description = "검색된 유저 정보")
+    public record UserSearchItem(
+            @Schema(description = "유저 ID", example = "1")
+            Long userId,
+
+            @Schema(description = "닉네임", example = "그림쟁이")
+            String nickname,
+
+            @Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/...")
+            String profileImgUrl
+    ) {
+        public static UserSearchItem from(User user, java.util.function.Function<String, String> urlResolver) {
+            return new UserSearchItem(
+                    user.getUserId(),
+                    user.getNickname(),
+                    urlResolver.apply(user.getProfileImageKey())
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/greaming/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/greaming/domain/user/repository/UserRepository.java
@@ -1,11 +1,15 @@
 package com.umc.greaming.domain.user.repository;
 
 import com.umc.greaming.domain.user.entity.User;
+import com.umc.greaming.domain.user.enums.UserState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);
+
+    List<User> findByNicknameContainingAndUserState(String nickname, UserState userState);
 }

--- a/src/main/java/com/umc/greaming/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/umc/greaming/domain/user/service/UserQueryService.java
@@ -10,8 +10,10 @@ import com.umc.greaming.domain.user.repository.UserProfileRepository;
 import com.umc.greaming.domain.user.repository.UserSpecialtyTagRepository;
 import com.umc.greaming.domain.user.dto.response.MyProfileTopResponse;
 import com.umc.greaming.domain.user.dto.response.UserInfoResponse;
+import com.umc.greaming.domain.user.dto.response.UserSearchResponse;
 import com.umc.greaming.domain.user.entity.User;
 import com.umc.greaming.domain.user.entity.UserProfile;
+import com.umc.greaming.domain.user.enums.UserState;
 import com.umc.greaming.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -85,6 +87,11 @@ public class UserQueryService {
                 profile.getUsagePurpose(),
                 profile.getWeeklyGoalScore()
         );
+    }
+
+    public UserSearchResponse searchByNickname(String nickname) {
+        List<User> users = userRepository.findByNicknameContainingAndUserState(nickname, UserState.ACTIVE);
+        return UserSearchResponse.from(users, this::resolvePublicUrl);
     }
 
     private String resolvePublicUrl(String key) {


### PR DESCRIPTION
## 📝 이슈 번호
Closes #(숫자)

## 🛠️ 변경 사항 (Changes)
- 닉네임 기반 유저 검색 api 추가
- 해당 id 값이 본인인지 확인하는 api 추가

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img width="629" height="109" alt="image" src="https://github.com/user-attachments/assets/cace8312-65db-49f7-a6eb-9d96e8714574" />


## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?