### PR TITLE
[FEAT] #83, #84 닉네임 중복 확인 및 프로필 설정 화면 조회 구현

### DIFF
--- a/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
+++ b/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
@@ -49,6 +49,8 @@ public enum SuccessStatus implements BaseStatus {
     USER_GET_INFO_SUCCESS("USER_200", HttpStatus.OK, "유저 정보 조회 성공"),
     USER_SEARCH_SUCCESS("USER_200", HttpStatus.OK, "유저 검색 성공"),
     USER_CHECK_IS_ME_SUCCESS("USER_200", HttpStatus.OK, "본인 여부 확인 성공"),
+    USER_CHECK_NICKNAME_SUCCESS("USER_200", HttpStatus.OK, "닉네임 중복 확인 성공"),
+    USER_GET_PROFILE_SETTINGS_SUCCESS("USER_200", HttpStatus.OK, "프로필 설정 정보 조회 성공"),
 
     //홈
     HOME_SUCCESS("HOME_200", HttpStatus.OK , "홈화면 조회 성공" ),

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
@@ -494,4 +494,99 @@ public interface UserApi {
     ResponseEntity<ApiResponse<com.umc.greaming.domain.user.dto.response.MyProfileTopResponse>> getMyProfileTop(
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     );
+
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = """
+                    입력한 닉네임이 이미 사용 중인지 확인합니다.
+                    
+                    - 회원가입 또는 프로필 수정 시 사용
+                    - `isAvailable: true`이면 사용 가능, `false`이면 이미 사용 중
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "닉네임 중복 확인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "USER_200",
+                                      "message": "닉네임 중복 확인 성공",
+                                      "result": {
+                                        "isAvailable": true
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/checkNickname")
+    ResponseEntity<ApiResponse<java.util.Map<String, Boolean>>> checkNickname(
+            @Parameter(description = "확인할 닉네임", example = "그림쟁이") @RequestParam String nickname
+    );
+
+    @Operation(
+            summary = "내 프로필 설정 정보 조회",
+            description = """
+                    내 프로필 설정 화면에 필요한 정보를 조회합니다.
+                    
+                    - 닉네임, 프로필 이미지, Journey 레벨, 자기소개
+                    - 전문 분야 태그, 관심 분야 태그
+                    - 주간 목표 점수
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 설정 정보 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "USER_200",
+                                      "message": "프로필 설정 정보 조회 성공",
+                                      "result": {
+                                        "nickname": "그림쟁이",
+                                        "profileImgUrl": "https://s3.amazonaws.com/...",
+                                        "level": "PAINTER",
+                                        "introduction": "그림 그리는 것을 좋아합니다",
+                                        "specialtyTags": ["일러스트", "캐릭터"],
+                                        "interestTags": ["풍경", "인물"],
+                                        "weeklyGoalScore": 5
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 또는 프로필을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/me/profile")
+    ResponseEntity<ApiResponse<com.umc.greaming.domain.user.dto.response.MyProfileSettingsResponse>> getMyProfileSettings(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    );
 }

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
@@ -85,4 +85,23 @@ public class UserController implements UserApi {
         com.umc.greaming.domain.user.dto.response.MyProfileTopResponse response = userQueryService.getMyProfileTop(userId);
         return ApiResponse.success(SuccessStatus.USER_GET_PROFILE_TOP_SUCCESS, response);
     }
+
+    @Override
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkNickname(
+            @RequestParam String nickname
+    ) {
+        boolean isAvailable = userQueryService.checkNicknameAvailability(nickname);
+        return ApiResponse.success(
+                SuccessStatus.USER_CHECK_NICKNAME_SUCCESS,
+                Map.of("isAvailable", isAvailable)
+        );
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<com.umc.greaming.domain.user.dto.response.MyProfileSettingsResponse>> getMyProfileSettings(
+            @AuthenticationPrincipal Long userId
+    ) {
+        com.umc.greaming.domain.user.dto.response.MyProfileSettingsResponse response = userQueryService.getMyProfileSettings(userId);
+        return ApiResponse.success(SuccessStatus.USER_GET_PROFILE_SETTINGS_SUCCESS, response);
+    }
 }

--- a/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileSettingsResponse.java
+++ b/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileSettingsResponse.java
@@ -1,0 +1,23 @@
+package com.umc.greaming.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyProfileSettingsResponse {
+
+    private String nickname;
+    private String profileImgUrl;
+    private String level;
+    private String introduction;
+    private List<String> specialtyTags;
+    private List<String> interestTags;
+    private Integer weeklyGoalScore;
+}

--- a/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileTopResponse.java
+++ b/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileTopResponse.java
@@ -1,12 +1,16 @@
 package com.umc.greaming.domain.user.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MyProfileTopResponse {
 
     private UserInformation userInformation;
@@ -14,6 +18,8 @@ public class MyProfileTopResponse {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UserInformation {
         private String nickname;
         private String profileImgUrl;
@@ -27,6 +33,8 @@ public class MyProfileTopResponse {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ChallengeCalendar {
         private List<String> dailyChallenge;
         private List<String> weeklyChallenge;


### PR DESCRIPTION
## 📝 이슈 번호
Closes #83 
Closes #84 

## 🛠️ 변경 사항 (Changes)
- 닉네임 중복 확인 구현
- 프로필 설정 화면 조회 구현

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?