### PR TITLE
[FEAT] 회원 탈퇴 API 구현 및 삭제된 유저 표시 처리

### DIFF
--- a/src/main/java/com/umc/greaming/domain/challenge/dto/response/ChallengeSubmissionCard.java
+++ b/src/main/java/com/umc/greaming/domain/challenge/dto/response/ChallengeSubmissionCard.java
@@ -39,12 +39,13 @@ public record ChallengeSubmissionCard(
         Integer bookmarkCount
 ) {
     public static ChallengeSubmissionCard from(Submission submission, String thumbnailUrl, String profileImageUrl) {
+        boolean deleted = submission.getUser().isDeleted();
         return new ChallengeSubmissionCard(
                 submission.getId(),
                 thumbnailUrl,
                 submission.getUser().getUserId(),
-                submission.getUser().getNickname(),
-                profileImageUrl,
+                deleted ? "삭제된 사용자" : submission.getUser().getNickname(),
+                deleted ? null : profileImageUrl,
                 submission.getLikeCount(),
                 submission.getCommentCount(),
                 submission.getBookmarkCount()

--- a/src/main/java/com/umc/greaming/domain/comment/dto/CommentInfo.java
+++ b/src/main/java/com/umc/greaming/domain/comment/dto/CommentInfo.java
@@ -25,11 +25,12 @@ public record CommentInfo(
         Boolean isWriter
 ) {
     public static CommentInfo from(Comment comment, String profileUrl, boolean isLiked, boolean isWriter) {
+        boolean deleted = comment.getUser().isDeleted();
         return new CommentInfo(
                 comment.getId(),
                 comment.getUser().getUserId(),
-                comment.getUser().getNickname(),
-                profileUrl,
+                deleted ? "삭제된 사용자" : comment.getUser().getNickname(),
+                deleted ? null : profileUrl,
                 comment.getContent(),
                 isLiked,
                 isWriter

--- a/src/main/java/com/umc/greaming/domain/comment/dto/ReplyInfo.java
+++ b/src/main/java/com/umc/greaming/domain/comment/dto/ReplyInfo.java
@@ -28,11 +28,12 @@ public record ReplyInfo(
         Boolean isWriter
 ) {
     public static ReplyInfo from(Reply reply, String profileUrl, boolean isWriter) {
+        boolean deleted = reply.getUser().isDeleted();
         return new ReplyInfo(
                 reply.getId(),
                 reply.getUser().getUserId(),
-                reply.getUser().getNickname(),
-                profileUrl,
+                deleted ? "삭제된 사용자" : reply.getUser().getNickname(),
+                deleted ? null : profileUrl,
                 reply.getContent(),
                 reply.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")),
                 isWriter

--- a/src/main/java/com/umc/greaming/domain/home/dto/response/HomeSubmissionCard.java
+++ b/src/main/java/com/umc/greaming/domain/home/dto/response/HomeSubmissionCard.java
@@ -39,12 +39,13 @@ public record HomeSubmissionCard(
         Integer bookmarkCount
 ) {
     public static HomeSubmissionCard from(Submission submission, String thumbnailUrl, String profileImageUrl) {
+        boolean deleted = submission.getUser().isDeleted();
         return new HomeSubmissionCard(
                 submission.getId(),
                 thumbnailUrl,
                 submission.getUser().getUserId(),
-                submission.getUser().getNickname(),
-                profileImageUrl,
+                deleted ? "삭제된 사용자" : submission.getUser().getNickname(),
+                deleted ? null : profileImageUrl,
                 submission.getLikeCount(),
                 submission.getCommentCount(),
                 submission.getBookmarkCount()

--- a/src/main/java/com/umc/greaming/domain/submission/dto/response/SubmissionInfo.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/response/SubmissionInfo.java
@@ -60,12 +60,13 @@ public record SubmissionInfo(
                                       List<String> sortedImages,
                                       List<TagInfo> tags,
                                       boolean isLiked) {
+        boolean deleted = submission.getUser().isDeleted();
         return new SubmissionInfo(
                 submission.getId(),
                 submission.getUser().getUserId(),
-                submission.getUser().getNickname(),
-                profileImageUrl,
-                level,
+                deleted ? "삭제된 사용자" : submission.getUser().getNickname(),
+                deleted ? null : profileImageUrl,
+                deleted ? null : level,
                 sortedImages,
                 submission.getLikeCount(),
                 submission.getCommentCount(),

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
@@ -589,4 +589,75 @@ public interface UserApi {
     ResponseEntity<ApiResponse<com.umc.greaming.domain.user.dto.response.MyProfileSettingsResponse>> getMyProfileSettings(
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     );
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    현재 로그인한 사용자의 계정을 탈퇴 처리합니다.
+
+                    - 소프트 삭제: 유저 상태를 DELETED로 변경합니다.
+                    - 리프레시 토큰을 삭제하여 로그아웃 처리합니다.
+                    - 기존 콘텐츠(게시물, 댓글 등)는 유지되며, 작성자는 '삭제된 사용자'로 표시됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "AUTH_200",
+                                      "message": "회원탈퇴 성공",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMM_401",
+                                      "message": "인증이 필요합니다.",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH_404",
+                                      "message": "회원을 찾을 수 없습니다.",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @DeleteMapping("/me")
+    ResponseEntity<ApiResponse<Void>> deleteUser(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    );
 }

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserController.java
@@ -104,4 +104,12 @@ public class UserController implements UserApi {
         com.umc.greaming.domain.user.dto.response.MyProfileSettingsResponse response = userQueryService.getMyProfileSettings(userId);
         return ApiResponse.success(SuccessStatus.USER_GET_PROFILE_SETTINGS_SUCCESS, response);
     }
+
+    @Override
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @AuthenticationPrincipal Long userId
+    ) {
+        userService.deleteUser(userId);
+        return ApiResponse.success(SuccessStatus.DELETE_USER_SUCCESS);
+    }
 }

--- a/src/main/java/com/umc/greaming/domain/user/entity/User.java
+++ b/src/main/java/com/umc/greaming/domain/user/entity/User.java
@@ -75,6 +75,10 @@ public class User extends BaseEntity {
         this.userState = UserState.DELETED;
     }
 
+    public boolean isDeleted() {
+        return this.userState == UserState.DELETED;
+    }
+
     public void registerProfile(String nickname, String introduction) {
         this.nickname = nickname;
         this.introduction = introduction;

--- a/src/main/java/com/umc/greaming/domain/user/service/UserService.java
+++ b/src/main/java/com/umc/greaming/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.umc.greaming.domain.user.service;
 
 import com.umc.greaming.common.exception.GeneralException;
 import com.umc.greaming.common.status.error.ErrorStatus;
+import com.umc.greaming.domain.auth.repository.RefreshTokenRepository;
 import com.umc.greaming.domain.tag.entity.Tag;
 import com.umc.greaming.domain.tag.repository.TagRepository;
 import com.umc.greaming.domain.user.dto.request.RegistInfoRequest;
@@ -26,6 +27,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserJournyRepository userJournyRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final TagRepository tagRepository;
     private final UserSpecialtyTagRepository userSpecialtyTagRepository;
     private final UserInterestTagRepository userInterestTagRepository;
@@ -77,6 +79,13 @@ public class UserService {
             userInterestTagRepository.flush();
             saveInterestTags(user, request.interestTags());
         }
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = findUser(userId);
+        user.delete();
+        refreshTokenRepository.deleteByUserId(userId);
     }
 
     private User findUser(Long userId) {


### PR DESCRIPTION
⏺ ## 📝 이슈 번호                                                                
  Closes #78                                                                      
                                                                                 
  ## 🛠️변경 사항 (Changes)                                                      
  - `DELETE /api/users/me` 회원 탈퇴 API 추가 (UserState -> DELETED, RefreshToken 
  삭제)                                                                          
  - User 엔티티에 `isDeleted()` 메서드 추가
  - 삭제된 유저의 콘텐츠 조회 시 작성자를 "삭제된 사용자"로 표시 (SubmissionInfo,
   CommentInfo, ReplyInfo, HomeSubmissionCard, ChallengeSubmissionCard)
  - OAuth2 재가입 처리: 탈퇴 유저가 동일 소셜 계정으로 로그인 시 기존 Provider
  해제 후 새 계정 생성

  ## 📸 스크린샷 또는 테스트 결과 (Evidence)


  ## ✅ 체크리스트 (Checklist)
  - [x] 로컬에서 빌드 및 테스트가 통과되었는가?
  - [x] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
  - [x] 커밋 메시지 규칙을 준수했는가?
