### PR TITLE
[FIX] Swagger 예시와 실제 DTO 간 불일치 수정

### DIFF
--- a/src/main/java/com/umc/greaming/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/umc/greaming/domain/comment/controller/CommentApi.java
@@ -40,13 +40,13 @@ public interface CommentApi {
                                       "code": "COMMENT_200",
                                       "message": "댓글 생성 성공",
                                       "result": {
-                                        "commentId": 10,
+                                        "comment_id": 10,
+                                        "user_id": 1,
                                         "writer_nickname": "그림쟁이",
                                         "writer_profileImgUrl": "https://s3.ap-northeast-2.amazonaws.com/greaming/profile/test.jpg",
                                         "content": "작품이 너무 멋져요!",
-                                        "createdAt": "2024.02.09 18:30",
-                                        "isWriter": true,
-                                        "isLiked": false
+                                        "isLiked": false,
+                                        "isWriter": true
                                       }
                                     }
                                     """
@@ -114,13 +114,15 @@ public interface CommentApi {
                                         "replies": [
                                           {
                                             "replyId": 25,
+                                            "userId": 2,
                                             "writer_nickname": "답글러",
                                             "writer_profileImgUrl": "https://s3.ap-northeast-2.amazonaws.com/greaming/profile/reply_user.jpg",
                                             "content": "저도 동감합니다.",
                                             "createdAt": "2024.02.09 19:00",
                                             "isWriter": false
                                           }
-                                        ]
+                                        ],
+                                        "totalCount": 1
                                       }
                                     }
                                     """

--- a/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
+++ b/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
@@ -192,7 +192,6 @@ public interface SubmissionApi {
                                       "result": {
                                         "submissionId": 100,
                                         "thumbnailUrl": "https://s3.ap-northeast-2.amazonaws.com/bucket/submission/thumb_100.jpg",
-                                        "title": "미리보기 제목",
                                         "tags": ["일러스트", "풍경"]
                                       }
                                     }
@@ -254,7 +253,6 @@ public interface SubmissionApi {
                                           "caption": "상세 설명입니다.",
                                           "tags": [{"tagId": 1, "tagName": "수채화"}],
                                           "liked": false,
-                                          "isWriter": true,
                                           "uploadAt": "2026-02-10T10:00:00"
                                         },
                                         "commentPage": {

--- a/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
@@ -15,7 +15,7 @@ public record SubmissionCreateRequest(
         @Schema(description = "게시글 내용", example = "열심히 그렸습니다.")
         String caption,
 
-        @Schema(description = "공개 범위 (PUBLIC / PRIVATE)", example = "PUBLIC")
+        @Schema(description = "공개 범위 (PUBLIC / CIRCLE)", example = "PUBLIC")
         @NotNull(message = "공개 범위는 필수입니다.")
         SubmissionVisibility visibility,
 

--- a/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionUpdateRequest.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionUpdateRequest.java
@@ -17,6 +17,9 @@ public record SubmissionUpdateRequest(
         @Schema(description = "수정할 댓글 허용 여부 (null일 경우 변경 없음)", example = "false")
         Boolean commentEnabled,
 
+        @Schema(description = "수정할 썸네일 이미지 S3 Key (null일 경우 변경 없음)", example = "submissions/user1/new_thumb.jpg")
+        String thumbnailKey,
+
         @Schema(description = "수정할 태그 목록 (보낼 경우 기존 태그 싹 지우고 이걸로 교체됨)", example = "[\"수정태그1\", \"태그2\"]")
         List<String> tags,
 

--- a/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
@@ -66,9 +66,7 @@ public class SubmissionCommandService {
             throw new GeneralException(ErrorStatus.SUBMISSION_NOT_AUTHORIZED);
         }
 
-        submission.updateInfo(request.title(), request.caption());
-        submission.updateVisibility(request.visibility());
-        submission.changeCommentEnabled(request.commentEnabled());
+        submission.update(request.title(), request.caption(), request.visibility(), request.commentEnabled(), request.thumbnailKey());
 
         if (request.imageList() != null) {
             submissionImageRepository.deleteAllBySubmission(submission);


### PR DESCRIPTION
## 📝 이슈 번호
Closes #105 

## 🛠️ 변경 사항 (Changes)
  - SubmissionCreateRequest visibility 설명 PRIVATE → CIRCLE로 수정
  - SubmissionApi Preview 응답 예시에서 존재하지 않는 title 필드 제거
  - SubmissionApi Detail 응답 예시에서 submission 내부의 isWriter 제거
  - CommentApi 댓글 생성 응답 예시 commentId → comment_id로 수정, 없는 createdAt
  제거, 누락된 user_id 추가
  - CommentApi 답글 목록 응답 예시에 누락된 totalCount, userId 추가
  - SubmissionUpdateRequest에 thumbnailKey 필드 추가
  - SubmissionCommandService.updateSubmission()에서 submission.update() 호출로
  변경하여 썸네일 수정 지원

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?