### PR TITLE
[FEAT] #107 특정유저 게시물 조회 구현 및 프로필 상단 userId 응답 추가

### DIFF
--- a/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
+++ b/src/main/java/com/umc/greaming/common/status/success/SuccessStatus.java
@@ -36,6 +36,7 @@ public enum SuccessStatus implements BaseStatus {
     SUBMISSION_UPDATE("SUBMISSION_200", HttpStatus.OK , "게시물 수정 성공" ),
     SUBMISSION_DELETED("SUBMISSION_200", HttpStatus.OK , "게시물 삭제 성공" ),
     SUBMISSION_CREATED("SUBMISSION_200", HttpStatus.OK , "게시물 추가 성공" ),
+    USER_SUBMISSION_LIST_SUCCESS("SUBMISSION_200", HttpStatus.OK, "유저 게시글 목록 조회 성공"),
 
     //댓글
     COMMENT_LIST_SUCCESS("COMMENT_200", HttpStatus.OK , "다음 댓글 불러오기 성공" ),

--- a/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
+++ b/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
@@ -9,6 +9,7 @@ import com.umc.greaming.domain.submission.dto.response.SubmissionDetailResponse;
 import com.umc.greaming.domain.submission.dto.response.SubmissionInfo;
 import com.umc.greaming.domain.submission.dto.response.SubmissionLikeResponse;
 import com.umc.greaming.domain.submission.dto.response.SubmissionPreviewResponse;
+import com.umc.greaming.domain.submission.dto.response.UserSubmissionsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -567,5 +568,67 @@ public interface SubmissionApi {
     ResponseEntity<ApiResponse<SubmissionLikeResponse>> toggleLike(
             @Parameter(description = "좋아요할 게시글 ID") @Positive @PathVariable("submissionId") Long submissionId,
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    );
+
+    @Operation(summary = "특정 유저의 게시글 목록 조회", description = """
+            특정 유저가 작성한 게시글 목록을 페이지네이션으로 조회합니다.
+            
+            - 최신순으로 정렬됩니다.
+            - 썸네일, 좋아요/댓글/북마크 수 등 간단한 정보만 반환합니다.
+            
+            **페이지 사이즈:**
+            - 기본값: 20
+            - 최소: 1
+            - 최대: 50
+            """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "유저 게시글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "SUBMISSION_200",
+                                      "message": "유저 게시글 목록 조회 성공",
+                                      "result": {
+                                        "submissions": [
+                                          {
+                                            "submissionId": 7,
+                                            "thumbnailUrl": "https://greaming-bucket.s3.ap-northeast-2.amazonaws.com/submissions/user1/thumb_uuid.jpg",
+                                            "userId": 1,
+                                            "nickname": "Picasso",
+                                            "profileImageUrl": null,
+                                            "likesCount": 0,
+                                            "commentCount": 0,
+                                            "bookmarkCount": 0
+                                          }
+                                        ],
+                                        "pageInfo": {
+                                          "currentPage": 1,
+                                          "pageSize": 20,
+                                          "totalPages": 5,
+                                          "totalElements": 100,
+                                          "isLast": false,
+                                          "isFirst": true
+                                        }
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/user/{userId}")
+    ResponseEntity<ApiResponse<UserSubmissionsResponse>> getUserSubmissions(
+            @Parameter(description = "조회할 유저 ID") @Positive @PathVariable("userId") Long userId,
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
+            @RequestParam(defaultValue = "1") @Positive int page,
+            @Parameter(description = "페이지 사이즈 (1-50)", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size,
+            @Parameter(hidden = true) @AuthenticationPrincipal Long loginUserId
     );
 }

--- a/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionController.java
+++ b/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionController.java
@@ -12,6 +12,7 @@ import com.umc.greaming.domain.submission.dto.response.SubmissionDetailResponse;
 import com.umc.greaming.domain.submission.dto.response.SubmissionInfo;
 import com.umc.greaming.domain.submission.dto.response.SubmissionLikeResponse;
 import com.umc.greaming.domain.submission.dto.response.SubmissionPreviewResponse;
+import com.umc.greaming.domain.submission.dto.response.UserSubmissionsResponse;
 import com.umc.greaming.domain.submission.service.SubmissionCommandService;
 import com.umc.greaming.domain.submission.service.SubmissionQueryService;
 import com.umc.greaming.domain.user.entity.User;
@@ -118,6 +119,22 @@ public class SubmissionController implements SubmissionApi {
         User user = findUserOrThrow(userId);
         SubmissionLikeResponse result = submissionCommandService.toggleLike(submissionId, user);
         return ApiResponse.success(SuccessStatus.LIKE_TOGGLE_SUCCESS, result);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<UserSubmissionsResponse>> getUserSubmissions(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @Parameter(hidden = true) @AuthenticationPrincipal Long loginUserId
+    ) {
+        User loginUser = null;
+        if (loginUserId != null) {
+            loginUser = userRepository.findById(loginUserId).orElse(null);
+        }
+
+        UserSubmissionsResponse result = submissionQueryService.getUserSubmissions(userId, page, size, loginUser);
+        return ApiResponse.success(SuccessStatus.USER_SUBMISSION_LIST_SUCCESS, result);
     }
 
     private User findUserOrThrow(Long userId) {

--- a/src/main/java/com/umc/greaming/domain/submission/dto/response/UserSubmissionCard.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/response/UserSubmissionCard.java
@@ -1,0 +1,44 @@
+package com.umc.greaming.domain.submission.dto.response;
+
+import com.umc.greaming.domain.submission.entity.Submission;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 게시글 카드 정보")
+public record UserSubmissionCard(
+        @Schema(description = "게시글 ID", example = "7")
+        Long submissionId,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://s3.../thumbnail.jpg")
+        String thumbnailUrl,
+
+        @Schema(description = "작성자 유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "작성자 닉네임", example = "Picasso")
+        String nickname,
+
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://s3.../profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "좋아요 수", example = "42")
+        Integer likesCount,
+
+        @Schema(description = "댓글 수", example = "10")
+        Integer commentCount,
+
+        @Schema(description = "북마크 수", example = "5")
+        Integer bookmarkCount
+) {
+    public static UserSubmissionCard from(Submission submission, String thumbnailUrl, String profileImageUrl) {
+        return new UserSubmissionCard(
+                submission.getId(),
+                thumbnailUrl,
+                submission.getUser().getUserId(),
+                submission.getUser().getNickname(),
+                profileImageUrl,
+                submission.getLikeCount(),
+                submission.getCommentCount(),
+                submission.getBookmarkCount()
+        );
+    }
+}

--- a/src/main/java/com/umc/greaming/domain/submission/dto/response/UserSubmissionsResponse.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/response/UserSubmissionsResponse.java
@@ -1,0 +1,40 @@
+package com.umc.greaming.domain.submission.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "유저별 게시글 리스트 응답 DTO")
+public record UserSubmissionsResponse(
+        @Schema(description = "게시글 카드 리스트")
+        List<UserSubmissionCard> submissions,
+
+        @Schema(description = "페이지 정보")
+        PageInfo pageInfo
+) {
+    @Schema(description = "페이지 정보")
+    public record PageInfo(
+            @Schema(description = "현재 페이지 번호", example = "1")
+            int currentPage,
+
+            @Schema(description = "페이지 크기", example = "20")
+            int pageSize,
+
+            @Schema(description = "전체 페이지 수", example = "5")
+            int totalPages,
+
+            @Schema(description = "전체 게시글 수", example = "100")
+            long totalElements,
+
+            @Schema(description = "마지막 페이지 여부", example = "false")
+            boolean isLast,
+
+            @Schema(description = "첫 페이지 여부", example = "true")
+            boolean isFirst
+    ) {
+    }
+
+    public static UserSubmissionsResponse of(List<UserSubmissionCard> submissions, PageInfo pageInfo) {
+        return new UserSubmissionsResponse(submissions, pageInfo);
+    }
+}

--- a/src/main/java/com/umc/greaming/domain/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/umc/greaming/domain/submission/repository/SubmissionRepository.java
@@ -42,4 +42,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
            "JOIN FETCH s.user " +
            "WHERE s.deletedAt IS NULL")
     Page<Submission> findAllByIsDeletedFalse(Pageable pageable);
+
+    @Query("SELECT s FROM Submission s " +
+           "JOIN FETCH s.user " +
+           "WHERE s.user.userId = :userId " +
+           "AND s.deletedAt IS NULL")
+    Page<Submission> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
+++ b/src/main/java/com/umc/greaming/domain/user/controller/UserApi.java
@@ -433,7 +433,7 @@ public interface UserApi {
             description = """
                     내 프로필 화면 상단 정보를 조회합니다.
                     
-                    - 닉네임, 프로필 이미지, Journey 레벨, 자기소개
+                    - 유저 ID, 닉네임, 프로필 이미지, Journey 레벨, 자기소개
                     - 팔로워/팔로잉 수
                     - 전문 분야 태그, 관심 분야 태그
                     - 챌린지 캘린더 정보 (일일/주간)
@@ -454,6 +454,7 @@ public interface UserApi {
                                       "message": "프로필 상단 정보 조회 성공",
                                       "result": {
                                         "userInformation": {
+                                          "userId": 1,
                                           "nickname": "그림쟁이",
                                           "profileImgUrl": "https://s3.amazonaws.com/...",
                                           "level": "PAINTER",

--- a/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileTopResponse.java
+++ b/src/main/java/com/umc/greaming/domain/user/dto/response/MyProfileTopResponse.java
@@ -21,6 +21,7 @@ public class MyProfileTopResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserInformation {
+        private Long userId;
         private String nickname;
         private String profileImgUrl;
         private String level;

--- a/src/main/java/com/umc/greaming/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/umc/greaming/domain/user/service/UserQueryService.java
@@ -33,7 +33,7 @@ public class UserQueryService {
     private final S3Service s3Service;
 
     public MyProfileTopResponse getMyProfileTop(Long userId) {
-        // userId null 체크
+
         if (userId == null) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         }
@@ -41,29 +41,24 @@ public class UserQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        // 팔로워/팔로잉 수 조회
         long followerCount = followRepository.countByFollowing_UserIdAndState(userId, FollowState.COMPLETED);
         long followingCount = followRepository.countByFollower_UserIdAndState(userId, FollowState.COMPLETED);
 
-        // 태그 조회
         List<String> specialtyTags = userSpecialtyTagRepository.findTagNamesByUserId(userId);
         List<String> interestTags = userInterestTagRepository.findTagNamesByUserId(userId);
 
-        // 레벨 조회
         String level = userJournyRepository.findByUser(user)
                 .map(userJourny -> userJourny.getJourneyLevel().name())
                 .orElse("SKETCHER");
 
-        // 챌린지 캘린더 (임시 빈 리스트)
         List<String> dailyChallenge = List.of();
         List<String> weeklyChallenge = List.of();
 
-        // 프로필 이미지 URL
         String profileImgUrl = resolvePublicUrl(user.getProfileImageKey());
 
-        // 응답 생성
         MyProfileTopResponse response = MyProfileTopResponse.builder()
                 .userInformation(MyProfileTopResponse.UserInformation.builder()
+                        .userId(userId)
                         .nickname(user.getNickname())
                         .profileImgUrl(profileImgUrl)
                         .level(level)


### PR DESCRIPTION
## 📝 이슈 번호
Closes #(숫자)

## 🛠️ 변경 사항 (Changes)
- 특정유저 게시물 조회 구현 
- 프로필 상단 userId 응답 추가

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?