### PR TITLE
[FEAT] #114 게시물 추가에 여정 매핑 로직 추가

### DIFF
--- a/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
+++ b/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
@@ -143,7 +143,9 @@ public interface SubmissionApi {
                                         "caption": "작품 설명입니다.",
                                         "tags": [{"tagId": 1, "tagName": "일러스트"}],
                                         "liked": false,
-                                        "uploadAt": "2026-02-10T10:00:00"
+                                        "uploadAt": "2026-02-10T10:00:00",
+                                        "field": "WEEKLY",
+                                        "challengeId": 123
                                       }
                                     }
                                     """
@@ -270,7 +272,9 @@ public interface SubmissionApi {
                                           "caption": "상세 설명입니다.",
                                           "tags": [{"tagId": 1, "tagName": "수채화"}],
                                           "liked": false,
-                                          "uploadAt": "2026-02-10T10:00:00"
+                                          "uploadAt": "2026-02-10T10:00:00",
+                                          "field": "WEEKLY",
+                                          "challengeId": 5
                                         },
                                         "commentPage": {
                                            "comments": [],
@@ -419,7 +423,9 @@ public interface SubmissionApi {
                                         "caption": "수정된 설명",
                                         "tags": [{"tagId": 2, "tagName": "수정태그"}],
                                         "liked": false,
-                                        "uploadAt": "2026-02-10T10:00:00"
+                                        "uploadAt": "2026-02-10T10:00:00",
+                                        "field": "WEEKLY",
+                                        "challengeId": 123
                                       }
                                     }
                                     """

--- a/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
+++ b/src/main/java/com/umc/greaming/domain/submission/controller/SubmissionApi.java
@@ -114,6 +114,7 @@ public interface SubmissionApi {
             - **field**: [WEEKLY, DAILY, FREE] 중 하나 필수
             - **visibility**: [PUBLIC, CIRCLE] 중 하나 필수
             - **thumbnailKey**: S3에서 발급받은 이미지 Key (URL 아님)
+            - **challengeId**: 챌린지 ID (선택, null 가능). WEEKLY/DAILY 작품인 경우 관련 챌린지 ID 입력
             """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -151,7 +152,7 @@ public interface SubmissionApi {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "입력값 검증 실패 (Enum 값 불일치 등)",
+                    description = "입력값 검증 실패 (Enum 값 불일치, challengeId 형식 오류 등)",
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ApiResponse.class),
@@ -161,6 +162,24 @@ public interface SubmissionApi {
                                       "isSuccess": false,
                                       "code": "COMM_400",
                                       "message": "field 값은 WEEKLY, DAILY, FREE 중 하나여야 합니다.",
+                                      "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 챌린지 (challengeId 제공 시)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "CHALLENGE_404",
+                                      "message": "챌린지를 찾을 수 없습니다.",
                                       "result": null
                                     }
                                     """

--- a/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
@@ -23,6 +23,9 @@ public record SubmissionCreateRequest(
         @NotNull(message = "분야(field)는 필수입니다.")
         SubmissionField field,
 
+        @Schema(description = "챌린지 Id", example = "123")
+        String challengeId,
+
         @Schema(description = "썸네일 이미지 S3 Key (URL 아님)", example = "submissions/user1/thumb_uuid.jpg")
         @NotBlank(message = "썸네일 이미지는 필수입니다.")
         String thumbnailKey,

--- a/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/request/SubmissionCreateRequest.java
@@ -24,7 +24,7 @@ public record SubmissionCreateRequest(
         SubmissionField field,
 
         @Schema(description = "챌린지 Id", example = "123")
-        String challengeId,
+        Long challengeId,
 
         @Schema(description = "썸네일 이미지 S3 Key (URL 아님)", example = "submissions/user1/thumb_uuid.jpg")
         @NotBlank(message = "썸네일 이미지는 필수입니다.")

--- a/src/main/java/com/umc/greaming/domain/submission/dto/response/SubmissionInfo.java
+++ b/src/main/java/com/umc/greaming/domain/submission/dto/response/SubmissionInfo.java
@@ -51,9 +51,15 @@ public record SubmissionInfo(
 
         @Schema(description = "업로드 일시", example = "2026-02-03T18:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime uploadAt
+        LocalDateTime uploadAt,
+
+        @Schema(description = "작품 분야", example = "WEEKLY")
+        String field,
+
+        @Schema(description = "챌린지 ID (null 가능)", example = "123")
+        Long challengeId
 ) {
-    // Factory Method
+
     public static SubmissionInfo from(Submission submission,
                                       String profileImageUrl,
                                       String level,
@@ -75,7 +81,9 @@ public record SubmissionInfo(
                 submission.getCaption(),
                 tags,
                 isLiked,
-                submission.getCreatedAt()
+                submission.getCreatedAt(),
+                submission.getField().name(),
+                submission.getChallenge() != null ? submission.getChallenge().getId() : null
         );
     }
 }

--- a/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
@@ -42,24 +42,40 @@ public class SubmissionCommandService {
     private final TagRepository tagRepository;
     private final WeeklyUserScoreRepository weeklyUserScoreRepository;
     private final S3Service s3Service;
+    private final com.umc.greaming.domain.challenge.repository.ChallengeRepository challengeRepository;
 
     public SubmissionInfo createSubmission(SubmissionCreateRequest request, User user) {
 
         log.info("=== createSubmission 시작 ===");
         log.info("User: {}", user != null ? user.getUserId() : "NULL");
         log.info("ProfileImageKey: {}", user != null ? user.getProfileImageKey() : "NULL");
-        log.info("Request - title: {}, thumbnailKey: {}", request.title(), request.thumbnailKey());
+        log.info("Request - title: {}, thumbnailKey: {}, challengeId: {}", 
+                request.title(), request.thumbnailKey(), request.challengeId());
 
-        Submission submission = Submission.builder()
+        Submission.SubmissionBuilder builder = Submission.builder()
                 .user(user)
                 .title(request.title())
                 .caption(request.caption())
                 .visibility(request.visibility())
                 .commentEnabled(request.commentEnabled())
                 .field(request.field())
-                .thumbnailKey(request.thumbnailKey())
-                .build();
+                .thumbnailKey(request.thumbnailKey());
 
+        if (request.challengeId() != null && !request.challengeId().trim().isEmpty()) {
+            try {
+                Long challengeIdLong = Long.parseLong(request.challengeId());
+                com.umc.greaming.domain.challenge.entity.Challenge challenge = 
+                        challengeRepository.findById(challengeIdLong)
+                                .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
+                builder.challenge(challenge);
+                log.info("Challenge 매핑 완료 - Challenge ID: {}", challengeIdLong);
+            } catch (NumberFormatException e) {
+                log.error("Invalid challengeId format: {}", request.challengeId());
+                throw new GeneralException(ErrorStatus.BAD_REQUEST);
+            }
+        }
+
+        Submission submission = builder.build();
         submission = submissionRepository.saveAndFlush(submission);
         log.info("Submission 저장 완료 - ID: {}", submission.getId());
 

--- a/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/com/umc/greaming/domain/submission/service/SubmissionCommandService.java
@@ -61,18 +61,12 @@ public class SubmissionCommandService {
                 .field(request.field())
                 .thumbnailKey(request.thumbnailKey());
 
-        if (request.challengeId() != null && !request.challengeId().trim().isEmpty()) {
-            try {
-                Long challengeIdLong = Long.parseLong(request.challengeId());
-                com.umc.greaming.domain.challenge.entity.Challenge challenge = 
-                        challengeRepository.findById(challengeIdLong)
-                                .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
-                builder.challenge(challenge);
-                log.info("Challenge 매핑 완료 - Challenge ID: {}", challengeIdLong);
-            } catch (NumberFormatException e) {
-                log.error("Invalid challengeId format: {}", request.challengeId());
-                throw new GeneralException(ErrorStatus.BAD_REQUEST);
-            }
+        if (request.challengeId() != null) {
+            com.umc.greaming.domain.challenge.entity.Challenge challenge = 
+                    challengeRepository.findById(request.challengeId())
+                            .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
+            builder.challenge(challenge);
+            log.info("Challenge 매핑 완료 - Challenge ID: {}", request.challengeId());
         }
 
         Submission submission = builder.build();


### PR DESCRIPTION
## 📝 이슈 번호
Closes #114 

## 🛠️ 변경 사항 (Changes)
- SubmissionCreateRequest에 챌린지Id 추가
- SubmissionCommandService 에 챌린지 매핑 로직 추가

## 📸 스크린샷 또는 테스트 결과 (Evidence)
<img src="https://github.com/mybookG/image/blob/main/Greaming/GreamingSubmissionCreate2.png?raw=true" width="500">

## ✅ 체크리스트 (Checklist)
- [ ] 로컬에서 빌드 및 테스트가 통과되었는가?
- [ ] 불필요한 주석(console.log 등)이나 코드는 제거했는가?
- [ ] 커밋 메시지 규칙을 준수했는가?